### PR TITLE
fix: omit 'text' -> omit 'content'

### DIFF
--- a/src/components/toaster/toaster.tsx
+++ b/src/components/toaster/toaster.tsx
@@ -17,7 +17,7 @@ interface ToastProps {
   role: 'alert' | 'status';
   class?: string;
 }
-export type ToastParams = Partial<Omit<ToastProps, 'text'>>
+export type ToastParams = Partial<Omit<ToastProps, 'content'>>
 
 export const ToasterContext = createContextId<{
   toaster: Signal<HTMLElement>,


### PR DESCRIPTION
`ToastParams` should not have a content parameter.