### PR TITLE
ref: export `ToastProps`

### DIFF
--- a/src/components/toaster/toaster.tsx
+++ b/src/components/toaster/toaster.tsx
@@ -4,7 +4,7 @@ import type { UlAttributes } from "../types";
 import { clsq, cssvar }  from '../utils';
 import styles from './toaster.scss?inline';
 
-interface ToastProps {
+export interface ToastProps {
   id: string;
   duration: number;
   position: 'start' | 'center' | 'end';


### PR DESCRIPTION
Because of TypeScript being TypeScript, `ToastProps` are sometimes required to type `toast.add` e.g. when using it with toast parameters (it somehow messes with the type of the props). It is also helpful for building a custom `useToaster` (component).